### PR TITLE
Update tapper.py

### DIFF
--- a/bot/core/tapper.py
+++ b/bot/core/tapper.py
@@ -273,7 +273,7 @@ class Tapper:
             if response.status == 200:
                 json_response = await response.json()
                 data_response = json_response['convert']
-                self.coin_balance = int(data_response['balance_USD'])
+                self.coin_balance = int(float(data_response['balance_USD']))
                 logger.success(
                     f"{self.session_name} | <green> Successfully convert <yellow>{self.btc_balance}</yellow> to <yellow>{float(self.btc_balance)*float(price)}</yellow> coin - Coin balance: <yellow>{data_response['balance_USD']}</yellow></green>")
             else:


### PR DESCRIPTION
Fix "Convert Error"

`File "/root/Cexio-Tap-bot/bot/core/tapper.py", line 276, in convertBTC
    self.coin_balance = int(data_response['balance_USD'])
ValueError: invalid literal for int() with base 10: '5668286.80'
2024-09-11 17:38:41 | ERROR    | 592 - [NAME1] | Unknown error: invalid literal for int() with base 10: '5668286.80'
Traceback (most recent call last):
  File "/root/Cexio-Tap-bot/bot/core/tapper.py", line 532, in run
    await self.convertBTC(http_client, authToken)
  File "/root/Cexio-Tap-bot/bot/core/tapper.py", line 276, in convertBTC
    self.coin_balance = int(data_response['balance_USD'])
ValueError: invalid literal for int() with base 10: '5721381.74'
2024-09-11 17:38:41 | ERROR    | 592 - [NAME2] | Unknown error: invalid literal for int() with base 10: '5721381.74'
2024-09-11 17:38:41 | INFO     | 508 - Session [NAME3]  logged in.
2024-09-11 17:38:42 | INFO     | 181 - Account name: [NAME4] - Balance: 5633037.2 - Btc balance: 0.4872 - Power: 2547620 CEXP
Traceback (most recent call last):
  File "/root/Cexio-Tap-bot/bot/core/tapper.py", line 532, in run
    await self.convertBTC(http_client, authToken)
  File "/root/Cexio-Tap-bot/bot/core/tapper.py", line 276, in convertBTC
    self.coin_balance = int(data_response['balance_USD'])
ValueError: invalid literal for int() with base 10: '5660808.42'
2024-09-11 17:38:42 | ERROR    | 592 - [NAME4] | Unknown error: invalid literal for int() with base 10: '5660808.42'
2024-09-11 17:38:43 | INFO     | 181 - Account name: [NAME3] - Balance: 5693446.29 - Btc balance: 0.469 - Power: 2577399 CEXP
2024-09-11 17:38:43 | INFO     | 508 - Session [NAME5] logged in.
2024-09-11 17:38:43 | INFO     | 508 - Session [NAME6] [OFFLINE] logged in.
Traceback (most recent call last):
  File "/root/Cexio-Tap-bot/bot/core/tapper.py", line 532, in run
    await self.convertBTC(http_client, authToken)
  File "/root/Cexio-Tap-bot/bot/core/tapper.py", line 276, in convertBTC
    self.coin_balance = int(data_response['balance_USD'])
ValueError: invalid literal for int() with base 10: '5720180.09'
2024-09-11 17:38:43 | ERROR    | 592 - [NAME3] | Unknown error: invalid literal for int() with base 10: '5720180.09'
2024-09-11 17:38:44 | INFO     | 181 - Account name: [NAME6] - Balance: 14130240.09 - Btc balance: 0.0 - Power: 3720665 CEXP
2024-09-11 17:38:45 | INFO     | 237 - [NAME6] | Claimed 23.3535 BTC | BTC Balance: 23.3535
2024-09-11 17:38:45 | INFO     | 181 - Account name: [NAME7] - Balance: 7631401.39 - Btc balance: 0.0 - Power: 2773232 CEXP
2024-09-11 17:38:46 | INFO     | 237 - [NAME8] | Claimed 17.4825 BTC | BTC Balance: 17.4825`